### PR TITLE
Capture more list types

### DIFF
--- a/lib/metadocs/elements/list_item.rb
+++ b/lib/metadocs/elements/list_item.rb
@@ -22,7 +22,7 @@ module Metadocs
       BULLET_GLYPHS = %w[● ○ ■ ❖ ➢ ➔ ◆ ★].freeze
 
       def bulleted?
-        BULLET_GLYPHS.include?(@glyph_symbol)
+        BULLET_GLYPHS.include?(@glyph_symbol) || @glyph_type == "GLYPH_TYPE_UNSPECIFIED"
       end
 
       NUMBER_TYPES = %w[DECIMAL ALPHA ROMAN].freeze

--- a/lib/metadocs/elements/list_item.rb
+++ b/lib/metadocs/elements/list_item.rb
@@ -19,7 +19,7 @@ module Metadocs
         @glyph_symbol = glyph_symbol
       end
 
-      BULLET_GLYPHS = %w[● ○ ■ ❖ ➢ ➔ ◆ ★].freeze
+      BULLET_GLYPHS = %w[● ○ ■ ❖ ➢ ➔ ◆ ★ -].freeze
 
       def bulleted?
         BULLET_GLYPHS.include?(@glyph_symbol) || @glyph_type == "GLYPH_TYPE_UNSPECIFIED"


### PR DESCRIPTION
# Issue
There are some lists that appear as lists in GDocs that are not imported as lists.  We also have some "hidden" lists that we _don't_ want to import as lists.  This logic allows two new cases of lists to import while keeping the functionality of "hidden" lists importing as paragraphs.

# Debugging
I created a [test doc](https://docs.google.com/document/d/1BSNEfGUktvMCbKgQYWeJdJYNudiwDcTc_C7eRjGkXZE/edit?usp=sharing) and logged the following `@glyph_type` and `@glyph_symbol` for the following list types

## Case 1: Normal Bulleted List
![Screenshot 2023-05-03 at 8 58 12 AM](https://user-images.githubusercontent.com/36971533/235977256-db9ed9d1-170f-409e-b429-9a193914af0b.png)

## Case 2: Normal Decimal List
![Screenshot 2023-05-03 at 8 58 40 AM](https://user-images.githubusercontent.com/36971533/235977153-02eb7710-0ccf-4439-afc9-2be9a8bacd53.png)

## Case 3: Hidden Lists
We do not want these lists imported as lists, but as paragraphs.
![Screenshot 2023-05-03 at 8 57 35 AM](https://user-images.githubusercontent.com/36971533/235977444-f22a2a62-a8ad-4161-82a4-0c999e3e700e.png)

## Case 4: Sneaky Bulleted Lists
Sometimes we have bulleted lists that are not auto-indented, but otherwise appear as bulleted lists.  These lists have a `glyph_symbol` of `nil` but a `glyph_type` of `GLYPH_TYPE_UNSPECIFIED`.  Even though they have a glyph_type, we still want these to be bulleted lists, hence adding the conditional `|| @glyph_type == "GLYPH_TYPE_UNSPECIFIED"` to the `bulleted?` boolean method.
![Screenshot 2023-05-03 at 8 57 06 AM](https://user-images.githubusercontent.com/36971533/235977494-f5def0a0-3326-47f4-b199-2717da74e380.png)

## Case 5: Dash Lists
I haven't seen dashes being used as bulleted lists, but it's entirely possible they could be - so adding the dash to the acceptable `GLYPH_SYMBOLS` seems like it would help catch those edge cases.
![Screenshot 2023-05-03 at 8 59 12 AM](https://user-images.githubusercontent.com/36971533/235977067-4cd35ccb-9b8e-42fa-972d-7774efdc7acb.png)

# Examples
[Source Doc](https://docs.google.com/document/d/1BSNEfGUktvMCbKgQYWeJdJYNudiwDcTc_C7eRjGkXZE/edit?usp=sharing)
![image](https://user-images.githubusercontent.com/36971533/235977834-b656b425-1ed5-41c2-85d7-4007453e7b32.png)

Import Example
BEFORE
![image](https://user-images.githubusercontent.com/36971533/235978767-1a80e4b9-8d19-4208-86af-212fd73294ef.png)

AFTER
![image](https://user-images.githubusercontent.com/36971533/235978704-b579e962-999c-4d87-bf6b-9c6ffcff606d.png)


CU-862jpga0u