### PR TITLE
Enhance Table HTML Rendering Support

### DIFF
--- a/lib/metadocs/elements/table.rb
+++ b/lib/metadocs/elements/table.rb
@@ -13,6 +13,14 @@ module Metadocs
         super()
         self.rows = rows
       end
+
+      def colgroup
+        "<colgroup>#{"<col>" * (self.max_column_count)}</colgroup>"
+      end
+
+      def max_column_count
+        self.rows.map { |row| row.cells.count }.max
+      end
     end
   end
 end

--- a/lib/metadocs/elements/table.rb
+++ b/lib/metadocs/elements/table.rb
@@ -14,10 +14,6 @@ module Metadocs
         self.rows = rows
       end
 
-      def colgroup
-        "<colgroup>#{"<col>" * (self.max_column_count)}</colgroup>"
-      end
-
       def max_column_count
         self.rows.map { |row| row.cells.count }.max
       end

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}">#{render_children}</td>)
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table><tbody>#{rows.join}</tbody></table>"
+      "<table>#{element.colgroup}<tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table><tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table>#{element.colgroup}<tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row
@@ -51,7 +51,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table>#{element.colgroup}<thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{rows.join}</tbody></table>"
+      "<table><tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -53,7 +53,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * element.max_column_count}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      "<td>#{children_html}</td>"
+      "<td>#{render_children}</td>"
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
+      "<td>#{children_html}</td>"
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,8 +38,6 @@ module Metadocs
     end
 
     def render_table_cell
-      # Empty cells must include empty paragraph for RTE markup
-      children_html = render_children.blank? ? "<p></p>" : render_children
       "<td>#{children_html}</td>"
     end
 

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      "<td>#{children_html}</td>"
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table>#{element.colgroup}<tbody>#{rows.join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table>#{element.colgroup}<tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row
@@ -51,7 +51,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table>#{element.colgroup}<thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,9 @@ module Metadocs
     end
 
     def render_table_cell
-      "<td>#{render_children}</td>"
+      # Empty cells must include empty paragraph for RTE markup
+      children_html = render_children.blank? ? "<p></p>" : render_children
+      "<td>#{children_html}</td>"
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}">#{render_children}</td>)
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
     end
 
     def render_tag


### PR DESCRIPTION
In order to be valid markup in our RTE, `Tables` need to include a `<colgroup>`.  Empty table cells also need to have an empty `<p>` tag as its child.  It seems best to add this feature at the base metadocs HTML rendering level, vs. manipulating the rendered HTML after the fact.  

In this PR I added a `<colgroup>` filled with an appropriate number of `<col>`s.  That number is determined by looking at the number of cells in each table row and returning the largest integer, in case we have tables with different cell counts/colspans.

Here are some tested examples:
**Single row with an empty cell**
Source Doc:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/d399c188-4f94-4bcc-9dd5-16bcb22cf48c)

Markup:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/c54e44cd-3f98-4af4-989e-f3f9a2e75196)

RTE:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/cd31db97-b23e-4883-91a6-c21951da0f90)

**Multiple rows, same column count, with an empty cell**
Source Doc:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/092d77f5-2696-410d-a614-d19ebbeea5b8)

Markup:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/ff4e3e41-3a17-4887-a739-4684425eb85e)

RTE:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/40f07562-1472-4880-bc7b-4dcd86443025)

Mutliple rows, different column counts, with an empty cell
Source Doc:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/52534464-b3ea-4cde-b3fb-28baf0a21e6f)

Markup:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/c65fb3d7-4dd0-4943-ad51-eeeef66e5e46)

RTE:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/a2580644-79fb-4b60-9ce0-f86d4ff9043b)


CU-866aegau2