### PR TITLE
Add Colspan and Rowspan Support for Tables

### DIFF
--- a/lib/metadocs/elements/metadata_table.rb
+++ b/lib/metadocs/elements/metadata_table.rb
@@ -49,10 +49,6 @@ module Metadocs
       rows[1].cells
     end
 
-    def perceptible_header_cells
-      rows[1].perceptible_cells
-    end
-
     protected
 
     def parse_metadata
@@ -92,13 +88,13 @@ module Metadocs
       data = {}
       data_rows = rows[1..]
 
-      unless data_rows.all? { |r| r.perceptible_cells.length == 2 }
+      unless data_rows.all? { |r| r.cells.length == 2 }
         @error = 'Data rows must have 2 cells'
         return nil
       end
 
       data_rows.each do |row|
-        key_cell, value_cell = row.perceptible_cells
+        key_cell, value_cell = row.cells
 
         unless all_text?(key_cell)
           @error = 'Key cells must only have text elements'
@@ -118,13 +114,13 @@ module Metadocs
       data = []
       data_rows = rows[2..]
 
-      headers = perceptible_header_cells.map { |c| join_text(c).downcase }
+      headers = header_cells.map { |c| join_text(c).downcase }
       if headers.any?(&:empty?)
         @error = 'Headers must not be empty'
         return nil
       end
 
-      unless data_rows.all? { |r| r.perceptible_cells.length == perceptible_header_cells.length }
+      unless data_rows.all? { |r| r.cells.length == header_cells.length }
         @error = 'All data rows must have the same number of cells as the header row'
         return nil
       end
@@ -132,7 +128,7 @@ module Metadocs
       data_rows.each do |row|
         entry = {}
         headers.each_with_index do |header, idx|
-          entry[header] = Elements::Body.with_renderers(renderers, children: row.perceptible_cells[idx].children.dup)
+          entry[header] = Elements::Body.with_renderers(renderers, children: row.cells[idx].children.dup)
         end
 
         next if entry.values.all? { |c| all_text?(c) && join_text(c).empty? }

--- a/lib/metadocs/elements/table.rb
+++ b/lib/metadocs/elements/table.rb
@@ -13,6 +13,14 @@ module Metadocs
         super()
         self.rows = rows
       end
+
+      def colgroup
+        "<colgroup>#{"<col>" * (self.max_column_count)}</colgroup>"
+      end
+
+      def max_column_count
+        self.rows.map { |row| row.cells.count }.max
+      end
     end
   end
 end

--- a/lib/metadocs/elements/table.rb
+++ b/lib/metadocs/elements/table.rb
@@ -14,10 +14,6 @@ module Metadocs
         self.rows = rows
       end
 
-      def colgroup
-        "<colgroup>#{"<col>" * (self.max_column_count)}</colgroup>"
-      end
-
       def max_column_count
         self.rows.map { |row| row.cells.count }.max
       end

--- a/lib/metadocs/elements/table_row.rb
+++ b/lib/metadocs/elements/table_row.rb
@@ -13,17 +13,6 @@ module Metadocs
         super()
         self.cells = cells
       end
-
-      def perceptible_cells
-        p_cells = []
-        i = 0
-        while i < cells.count
-          cell = cells[i]
-          p_cells << cell
-          i += cell.column_span
-        end
-        p_cells
-      end
     end
   end
 end

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}">#{render_children}</td>)
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table><tbody>#{rows.join}</tbody></table>"
+      "<table>#{element.colgroup}<tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table><tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table>#{element.colgroup}<tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row
@@ -51,7 +51,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table>#{element.colgroup}<thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{rows.join}</tbody></table>"
+      "<table><tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -53,7 +53,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * element.max_column_count}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
+      "<td>#{children_html}</td>"
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,8 +38,6 @@ module Metadocs
     end
 
     def render_table_cell
-      # Empty cells must include empty paragraph for RTE markup
-      children_html = render_children.blank? ? "<p></p>" : render_children
       "<td>#{children_html}</td>"
     end
 

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      "<td>#{children_html}</td>"
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -18,7 +18,7 @@ module Metadocs
       rows = element.metadata.map do |k, v|
         "<tr><td>#{k}</td><td>#{v.render(type)}</td></tr>"
       end
-      "<table>#{element.colgroup}<tbody>#{rows.join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{rows.join}</tbody></table>"
     end
 
     def render_list_item
@@ -30,7 +30,7 @@ module Metadocs
     end
 
     def render_table
-      "<table>#{element.colgroup}<tbody>#{render_all(element.rows).join}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><tbody>#{render_all(element.rows).join}</tbody></table>"
     end
 
     def render_table_row
@@ -51,7 +51,7 @@ module Metadocs
         tds = entry.map { |_k_, v| "<td>#{v.render(type)}</td>" }.join
         "<tr>#{tds}</tr>"
       end.join
-      "<table>#{element.colgroup}<thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
+      "<table><colgroup>#{"<col>" * (element.max_column_count)}</colgroup><thead><tr>#{thead}</tr></thead><tbody>#{rows}</tbody></table>"
     end
 
     def render_text

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,9 @@ module Metadocs
     end
 
     def render_table_cell
-      "<td>#{render_children}</td>"
+      # Empty cells must include empty paragraph for RTE markup
+      children_html = render_children.blank? ? "<p></p>" : render_children
+      "<td>#{children_html}</td>"
     end
 
     def render_tag

--- a/lib/metadocs/html_renderer.rb
+++ b/lib/metadocs/html_renderer.rb
@@ -38,7 +38,7 @@ module Metadocs
     end
 
     def render_table_cell
-      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}">#{render_children}</td>)
+      %(<td colspan="#{element.column_span}" rowspan="#{element.row_span}>#{render_children}</td>)
     end
 
     def render_tag

--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -282,7 +282,7 @@ module Metadocs
         # Parse column_span; see documentation below
         num_of_cells_to_merge_in_current_row = 0
 
-        cell_ids.each_with_index do |cell_id, idx|
+        cell_ids.each_with_index do |cell_id, idx_in_row|
           # The Google API represents all cells as TableCells, even merged cells
           # I.e. a cell consisting of two merged cells still returns as two TableCells with varying col/rowspans.
           # We want to skip over merged cells when parsing the table.
@@ -293,11 +293,11 @@ module Metadocs
           # then skip parsing 1 TableCell at current TableCell index for y-1 subsequent TableRows.
           # Note: You shouldn't be able to create a monstrosity in GDocs where a TableCell has
           # *both* a row_span and column_span greater than 1, but this will support parsing that edge case.
-          if num_of_cells_to_merge_in_current_row > 0 || (num_of_cells_to_merge_by_row_idx[idx] && num_of_cells_to_merge_by_row_idx[idx] > 0)
+          if num_of_cells_to_merge_in_current_row > 0 || (num_of_cells_to_merge_by_row_idx[idx_in_row] && num_of_cells_to_merge_by_row_idx[idx_in_row] > 0)
             if num_of_cells_to_merge_in_current_row > 0
               num_of_cells_to_merge_in_current_row -= 1
-            elsif (num_of_cells_to_merge_by_row_idx[idx] && num_of_cells_to_merge_by_row_idx[idx] > 0)
-              num_of_cells_to_merge_by_row_idx[idx] -= 1
+            elsif (num_of_cells_to_merge_by_row_idx[idx_in_row] && num_of_cells_to_merge_by_row_idx[idx_in_row] > 0)
+              num_of_cells_to_merge_by_row_idx[idx_in_row] -= 1
             end
             next
           end
@@ -307,7 +307,7 @@ module Metadocs
           if current_cell_styles.column_span > 1
             num_of_cells_to_merge_in_current_row = current_cell_styles.column_span.to_i - 1
           elsif current_cell_styles.row_span > 1
-            num_of_cells_to_merge_by_row_idx[idx] = current_cell_styles.row_span.to_i - 1
+            num_of_cells_to_merge_by_row_idx[idx_in_row] = current_cell_styles.row_span.to_i - 1
           end
 
           cell = Elements::TableCell.with_renderers(

--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -272,11 +272,44 @@ module Metadocs
     def parse_table_reference(_mapping, reference_mapping, _node)
       table = Elements::Table.with_renderers(renderers)
 
+      # Parse row_span; see documentation below
+      num_of_cells_to_merge_by_row_idx = {}
+
       reference_mapping.table_rows.each do |cell_ids|
         row = Elements::TableRow.with_renderers(renderers)
         table.rows << row
-        cell_ids.each do |cell_id|
+
+        # Parse column_span; see documentation below
+        num_of_cells_to_merge_in_current_row = 0
+
+        cell_ids.each_with_index do |cell_id, idx|
+          # The Google API represents all cells as TableCells, even merged cells
+          # I.e. a cell consisting of two merged cells still returns as two TableCells with varying col/rowspans.
+          # We want to skip over merged cells when parsing the table.
+          # `num_of_cells_to_merge_in_current_row` [Integer] If a TableCell has a column_span
+          # of (x) > 1, then skip parsing x-1 subsequent TableCells.
+          # `num_of_cells_to_merge_by_row_idx` [Hash] where key is a row_idx,
+          # and value is the number of cells to merge at idx. If TableCell has row_span of (y) > 1,
+          # then skip parsing 1 TableCell at current TableCell index for y-1 subsequent TableRows.
+          # Note: You shouldn't be able to create a monstrosity in GDocs where a TableCell has
+          # *both* a row_span and column_span greater than 1, but this will support parsing that edge case.
+          if num_of_cells_to_merge_in_current_row > 0 || (num_of_cells_to_merge_by_row_idx[idx] && num_of_cells_to_merge_by_row_idx[idx] > 0)
+            if num_of_cells_to_merge_in_current_row > 0
+              num_of_cells_to_merge_in_current_row -= 1
+            elsif (num_of_cells_to_merge_by_row_idx[idx] && num_of_cells_to_merge_by_row_idx[idx] > 0)
+              num_of_cells_to_merge_by_row_idx[idx] -= 1
+            end
+            next
+          end
+
           cell_mapping = source_map[cell_id]
+          current_cell_styles = cell_mapping['element'].table_cell_style
+          if current_cell_styles.column_span > 1
+            num_of_cells_to_merge_in_current_row = current_cell_styles.column_span.to_i - 1
+          elsif current_cell_styles.row_span > 1
+            num_of_cells_to_merge_by_row_idx[idx] = current_cell_styles.row_span.to_i - 1
+          end
+
           cell = Elements::TableCell.with_renderers(
             renderers,
             column_span: cell_mapping['element'].table_cell_style.column_span,


### PR DESCRIPTION
# Supporting Colspan and Rowspan in GDoc Tables
_Note: this branch now includes the work of #2_

# Context
The Google Docs API represents _all_ cells as TableCells, regardless of if they are merged cells or individual cells.  The only difference between them is their colspan/rowspan values.  For Metadata tables, we addressed the colspan variations via the `perceptible_cells` method in the TableRow class.  However, knowing now that it affects all tables, and has the same effect for `rowspan`, I'm wondering if we should address it at the parsing level.

Note: I have not yet refactored `perceptible_cells` out of the Metadata tables, in case there are some logic flaws in my current implementation that should be addressed first.  I believe that refactor would need to happen since this refactor is at the parsing level, but I want to double-check that.

# Parsing
## Colspan > 1
We want to skip over merged cells when parsing the TableRow.
`num_of_cells_to_merge_in_current_row` is an Integer that represents the number of subsequent TableCells that should be skipped during the current TableRow parsing.

## Rowspan > 1
We want to skip over merged cells in subsequent TableRows at the same cell index.
`num_of_cells_to_merge_by_row_idx` is a Hash where the keys represent `row indexes` and the values represent how many subsequent TableRows should have the TableCell at that `row index` skipped.

## Colspan AND Rowspan > 1
I couldn't find a way in the GDocs UI to merge cells horizontally _and_ vertically, but wanted to solve for that edge case regardless.  We decrement applicable `colspan` and/or `rowspan` variables before skipping parsing a TableCell.

# Examples
## Colspan
GDoc
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/cab253bc-d9ec-4296-b6da-d98aa99c1dd1)

Import
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/3027d060-e823-43bd-bfd9-afb45899f99a)

HTML
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/e73de416-9e33-4c7f-94e4-518ccfb3101c)

## Rowspan
Gdoc 
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/71eaf0b7-41e0-4f0e-96c4-74828af53926)

Import
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/e18ee09c-4d5a-4d97-8909-585667ad0bc6)

HTML
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/200cb42c-5f90-43bc-915f-08c8048813ee)

## Colspan & Rowspan (in the same Table, not for the same Cell)
GDoc
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/4e3ca9fe-6685-46f3-aa07-cde74531577e)

Import
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/4197fd79-5779-4f7f-ae84-e1aa24711aba)

HTML
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/6eb21c80-bce1-476a-8e94-d08debfcb8c2)
