### PR TITLE
Updates for Odell

### DIFF
--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -64,7 +64,7 @@ module Metadocs
       end
     end
 
-    def self.parse(google_authorization, doc_id, tags: [], empty_tags: [], metadata_table_spec: [], renderers: [])
+    def self.parse(google_authorization, doc_id, tags: [], empty_tags: [], metadata_table_spec: [], renderers: {})
       document = Metadocs::GoogleDocument.new(google_authorization, doc_id)
       parser = new(
         document.document,
@@ -232,7 +232,9 @@ module Metadocs
 
     # currently only replaces image references
     def parse_paragraph_reference(_mapping, reference_mapping, _node)
-      first_nearby_text = reference_mapping["element"].content.map(&:paragraph).first.elements.map(&:text_run).compact.map(&:content).join.strip
+      paragraph = reference_mapping["element"].content.map(&:paragraph).first
+      return unless paragraph
+      first_nearby_text = paragraph.elements.map(&:text_run).compact.map(&:content).join.strip
       first_nearby_text = "\"#{first_nearby_text}\"" unless first_nearby_text.empty?
       first_nearby_text = "{no text in table cell}" if first_nearby_text.empty?
       if (obj_id = reference_mapping.positioned_object_id)


### PR DESCRIPTION
### Changes
- Updated the default parameter for `renderers` to be a hash instead of an array. On line 25 and 34, you can see it was meant to be a hash.
- If you look at this [Unit google doc](https://docs.google.com/document/d/1PAfWdN4ot3p5bnF6RMG_rvDHKRURB5a-Cu7UZAAThUg/edit#heading=h.fdmgu6seph5f), and look between each table, there is some blank section that has some markup with no content in it (see below screenshot where I've highlighted it). That is causing the parse to break because it is assuming there is some content in it. I'm not entirely sure how this is created in google docs - it doesn't seem to be created via tabbing, etc.

<img width="1294" alt="Screenshot 2023-07-27 at 8 49 16 AM" src="https://github.com/openupresources/metadocs-rb/assets/15858541/8614b8b6-74c9-4a6f-805d-a19bcf6e3696">

### Dev Questions
- @danblaker mentioned that we may want to fork this repo for Odell specific changes, but these changes seem innocuous enough to just add. Thoughts?
- Can you check my understanding of this? A parsed doc appears to have an attribute `parsed_images` which separately has all image elements. When importing, it creates all image records first before importing the file. This is because in our cms, images are supporting materials, so to embed an image in a rte, the image record will first need to exist. 

### Major Learnings
- For PK5, the credentials are for a service account for the email [open-up-cms-view-access@open-up-cms.iam.gserviceaccount.com](mailto:open-up-cms-view-access@open-up-cms.iam.gserviceaccount.com) who has view only access to the folders/files. For testing, I just copied the file and made it accessible by anyone.
- `parsed_doc.metadata` will return the [bbdoc_example] tag values
- You can then do `parsed_doc["metadata_tag"]` to just return the contents of that table
- For a paragraph element, can call render(:html) on it to render all text elements within it (or alternatively (:text) 