### PR TITLE
Bug: Handle table rows that only include merged cells

### DIFF
--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -323,7 +323,7 @@ module Metadocs
           )
           cell.children = walk_ast(cell_mapping, cell_bbdocs.parse(cell_mapping.source))
         end
-        table.rows << row if row.cells.any? # Don't create empty rows when entire row has been merged
+        table.rows << row if row.cells.any? # Don't create an empty row when all of the row's cells have been merged with another row's cells
       end
 
       @tables << table

--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -277,7 +277,6 @@ module Metadocs
 
       reference_mapping.table_rows.each do |cell_ids|
         row = Elements::TableRow.with_renderers(renderers)
-        table.rows << row
 
         # Parse column_span; see documentation below
         num_of_cells_to_merge_in_current_row = 0
@@ -324,6 +323,7 @@ module Metadocs
           )
           cell.children = walk_ast(cell_mapping, cell_bbdocs.parse(cell_mapping.source))
         end
+        table.rows << row if row.cells.any? # Don't create empty rows when entire row has been merged
       end
 
       @tables << table

--- a/lib/metadocs/parser.rb
+++ b/lib/metadocs/parser.rb
@@ -382,7 +382,6 @@ module Metadocs
         else
           # Merge related children
           parent_paragraph_idx = key_children.index { |c| c.is_a?(Elements::Paragraph) }
-          binding.pry if parent_paragraph_idx.nil?
           raise ParserError.new("Invalid nesting of tags near '#{key_children.map(&:render).join}'.") if parent_paragraph_idx.nil?
           parent_paragraph = key_children[parent_paragraph_idx]
           if parent_paragraph_idx.positive?


### PR DESCRIPTION
# Supporting Merged Rows

# Context
Accounting for merged cells was addressed in #3, but what wasn't addressed is if an entire row has been merged.  Brief context: The Google Docs API represents _all_ cells as table cells, whether they are merged or not.  The only difference is their colspan/rowspan values.  

When parsing a table, we previously created a `TableRow` element, iterated through the row's cells, processed out the merged cells, recomputed colspan/rowspan correctly, and then added those `TableCell`s to the `TableRow`.  What this misses is if an entire row has been merged.  

By moving the `TableRow` addition until after the cells have been processed, we will be able to check if there are any valid/perceptible cells.  If there are none aka the entire row has been merged, then we don't want to add the `TableRow` to the `Table`.

# Testing and Discovery
This error was discovered when some metadata tables were being parsed as `Table` elements instead of `MetadataTable` elements.  One of the checks for a `key_value` `MetadataTable` is that each row (other than the first) must have a length of 2.  If you have a table that looks like:
```
|  metadata-table  |
|  key_1  |  value_1  |
|  key_2  |  value_2  |
```
Then you'll have a table that has:
row_1 -> 1 cell
row_2 -> 2 cells
row_3 -> 2 cells

If you then merge the bottom row:
```
|  metadata-table  |
|  key_1  |  value_1  |
```
Then you'll have a table that has:
row_1 -> 1 cell
row_2 -> 2 cells
row_3 -> 0 cells

Which fails the `MetadataTable` parser check.

In this lesson ([Gdoc](https://docs.google.com/document/d/1Cz24niWqkmARQC1k8_gNy1KkBU5lIMXnH1IVsbrZWUo/edit) | [Prod](https://open-up-cms.herokuapp.com/pk5_math/nodes/en/ccss/grade-1/unit)), the `launch-metadata` table has a merged last row.  On production, you can see the `launch-metadata` section was skipped on import.  Locally, with this fix, I can confirm that it imports:
![image](https://github.com/openupresources/metadocs-rb/assets/36971533/0d8d7977-3bd3-4219-adbb-0ef17927e258)

![image](https://github.com/openupresources/metadocs-rb/assets/36971533/c37f8e07-3d2b-41c6-92c4-e1fb98d5c382)
